### PR TITLE
Fix import spacing

### DIFF
--- a/src/lib/components/avatar-group/index.ts
+++ b/src/lib/components/avatar-group/index.ts
@@ -1,5 +1,5 @@
 import AvatarGroup from './AvatarGroup.svelte'
 import { avatarGroupTheme } from './theme'
-import { type  AvatarGroupProps } from './type'
+import { type AvatarGroupProps } from './type'
 
 export { avatarGroupTheme, AvatarGroup, type AvatarGroupProps }

--- a/src/lib/components/avatar/index.ts
+++ b/src/lib/components/avatar/index.ts
@@ -1,5 +1,5 @@
 import Avatar from './Avatar.svelte'
 import { avatarTheme } from './theme'
-import { type  AvatarProps } from './type'
+import { type AvatarProps } from './type'
 
 export { avatarTheme, Avatar, type AvatarProps }


### PR DESCRIPTION
## Summary
- fix spacing in `type` imports for Avatar and AvatarGroup

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841165c71bc832bac0d3db85c86810f