### PR TITLE
Fix separator avatar doc

### DIFF
--- a/src/lib/components/separator/type.ts
+++ b/src/lib/components/separator/type.ts
@@ -50,18 +50,18 @@ export interface SeparatorProps extends HTMLAttributes<HTMLElement> {
 	 */
 	icon?: string
 
-	/**
-	 * The avatar to be displayed inside the button.
-	 * Can be used if you don't want to specify leading or trailing icon specifically.
-	 *
-	 * @example
-	 * ```svelte
-	 * <Separator avatar="{{
-	 *       src: 'https://github.com/nuxt.png'
-	 *     }}" />
-	 * ```
-	 */
-	avatar?: AvatarProps;
+       /**
+        * The avatar to be displayed inside the separator.
+        * Can be used if you don't want to specify leading or trailing icon specifically.
+        *
+        * @example
+        * ```svelte
+        * <Separator avatar="{{
+        *       src: 'https://github.com/nuxt.png'
+        *     }}" />
+        * ```
+        */
+       avatar?: AvatarProps;
 
 	/**
 	 * Optional text label to display with the separator.


### PR DESCRIPTION
## Summary
- fix avatar JSDoc in `SeparatorProps`

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684118dec6bc832b9c83ad0a0f435579